### PR TITLE
commented out gradient

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -116,17 +116,14 @@ form label {
   z-index: 1;
 }
 
-.page-header-fade {
-    /* background-color: yellow; */
-    /* opacity: .5; */
+/*.page-header-fade {
     height:600px;
     position:absolute;
-    /* top: 0; */
     bottom: 0;
     left: 0;
     right: 0;
     background: linear-gradient(to bottom, rgba(22,30,36,0), rgba(22,30,36,1));
-}
+}*/
 
 .header {
   font-family: 'Amatic SC', cursive;


### PR DESCRIPTION
commented out gradient to make room for integrated one (built in w/ background). Latter should appear the same only w/ added benefit of not causing issues when search result div is expanded via `overflow: auto` or `overflow:scroll` and requires more vertical space